### PR TITLE
Fixes #3

### DIFF
--- a/ckanext/odm_nav/plugin.py
+++ b/ckanext/odm_nav/plugin.py
@@ -43,18 +43,18 @@ class OdmNavPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     return {
             'license_id': toolkit._('License'),
-            'tags': toolkit._('Topics'),
             'organization': toolkit._('Organizations'),
             'res_format': toolkit._('Formats'),
             'extras_odm_language': toolkit._('Language'),
             'extras_odm_spatial_range': toolkit._('Country')
             }
 
+    # NOTE: Add support for tags -> 'tags': toolkit._('Topics'),
+
   def group_facets(self, facets_dict, group_type, package_type):
 
     return {
             'license_id': toolkit._('License'),
-            'tags': toolkit._('Topics'),
             'organization': toolkit._('Organizations'),
             'res_format': toolkit._('Formats'),
             'extras_odm_language': toolkit._('Language'),
@@ -65,7 +65,6 @@ class OdmNavPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     return {
             'license_id': toolkit._('License'),
-            'tags': toolkit._('Topics'),
             'res_format': toolkit._('Formats'),
             'extras_odm_language': toolkit._('Language'),
             'extras_odm_spatial_range': toolkit._('Country')

--- a/ckanext/odm_nav/plugin.py
+++ b/ckanext/odm_nav/plugin.py
@@ -40,41 +40,36 @@ class OdmNavPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
   # IFacets
   def dataset_facets(self, facets_dict, package_type):
-    facets_dict = {
-              'license_id': toolkit._('License'),
-              'tags': toolkit._('Topics'),
-              'organization': toolkit._('Organizations'),
-              'groups': toolkit._('Groups'),
-              'res_format': toolkit._('Formats'),
-              'odm_language': toolkit._('Language'),
-              'odm_spatial_range': toolkit._('Country')
-              }
 
-    return facets_dict
+    return {
+            'license_id': toolkit._('License'),
+            'tags': toolkit._('Topics'),
+            'organization': toolkit._('Organizations'),
+            'res_format': toolkit._('Formats'),
+            'extras_odm_language': toolkit._('Language'),
+            'extras_odm_spatial_range': toolkit._('Country')
+            }
 
   def group_facets(self, facets_dict, group_type, package_type):
-    group_facets = {
-              'license_id': toolkit._('License'),
-              'tags': toolkit._('Topics'),
-              'organization': toolkit._('Organizations'),
-              'res_format': toolkit._('Formats'),
-              'odm_language': toolkit._('Language'),
-              'odm_spatial_range': toolkit._('Country')
-              }
 
-    return group_facets
+    return {
+            'license_id': toolkit._('License'),
+            'tags': toolkit._('Topics'),
+            'organization': toolkit._('Organizations'),
+            'res_format': toolkit._('Formats'),
+            'extras_odm_language': toolkit._('Language'),
+            'extras_odm_spatial_range': toolkit._('Country')
+            }
 
   def organization_facets(self, facets_dict, organization_type, package_type):
-    organization_facets = {
-              'license_id': toolkit._('License'),
-              'tags': toolkit._('Topics'),
-              'groups': toolkit._('Groups'),
-              'res_format': toolkit._('Formats'),
-              'odm_language': toolkit._('Language'),
-              'odm_spatial_range': toolkit._('Country')
-              }
 
-    return organization_facets
+    return {
+            'license_id': toolkit._('License'),
+            'tags': toolkit._('Topics'),
+            'res_format': toolkit._('Formats'),
+            'extras_odm_language': toolkit._('Language'),
+            'extras_odm_spatial_range': toolkit._('Country')
+            }
 
   # IRoutes
   def before_map(self, m):

--- a/ckanext/odm_nav/templates/header.html
+++ b/ckanext/odm_nav/templates/header.html
@@ -130,7 +130,7 @@
           <h4>{{ _('Browse by topic') }}</h4>
           {% for top_topic in h.odm_nav_top_topics() %}
             {% set tag_name = h.odm_nav_tag_for_topic(top_topic) %}
-            <a class="header_tag" href="{% url_for controller='package', action='search', tags=tag_name %}">{{ h.odm_nav_get_localized_tag(top_topic) }}</a>
+            <a class="header_tag" href="{% url_for controller='package', action='search', extras_taxonomy=tag_name %}">{{ h.odm_nav_get_localized_tag(top_topic) }}</a>
           {% endfor %}
          </div>
          <div class="span3 col2 header-selection">

--- a/ckanext/odm_nav/templates/home/snippets/search.html
+++ b/ckanext/odm_nav/templates/home/snippets/search.html
@@ -15,7 +15,7 @@
   <div class="tags">
     <h3>{{ _('Popular tags') }}</h3>
     {% for tag in tags %}
-      <a class="tag" href="{% url_for controller='package', action='search', tags=tag.name %}">{{ h.odm_nav_get_localized_tag(tag.display_name) }}</a>
+      <a class="tag" href="{% url_for controller='package', action='search', extra_taxonomy=tag.name %}">{{ h.odm_nav_get_localized_tag(tag.display_name) }}</a>
     {% endfor %}
   </div>
 </div>

--- a/ckanext/odm_nav/templates/snippets/package_item.html
+++ b/ckanext/odm_nav/templates/snippets/package_item.html
@@ -42,13 +42,7 @@ Example:
               {% endif %}
             {% endblock %}
             {% block heading_title %}
-             {% if package.type == h.odm_library_get_dataset_type() %}
-              <i class="fa fa-book icon icon-book glyphicon glyphicon-book"></i>
-              {{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='package', type=package.type, action='read', id=package.name)) }}
-             {% else %}
-              <i class="fa fa-sitemap icon icon-sitemap glyphicon glyphicon-sitemap"></i>
-              {{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='package', type=package.type, action='read', id=package.name)) }}
-             {% endif %}
+						 {{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='package', type=package.type, action='read', id=package.name)) }}
             {% endblock %}
             {% block heading_meta %}
               {% if package.get('state', '').startswith('draft') %}

--- a/ckanext/odm_nav/templates/snippets/tag_list.html
+++ b/ckanext/odm_nav/templates/snippets/tag_list.html
@@ -6,7 +6,7 @@
 <ul class="{{ _class }}">
   {% for tag in tags %}
   <li>
-    <a class="tag" href="{% url_for controller='package', action='search', tags=tag.name %}">{{ h.odm_nav_get_localized_tag(tag.display_name) }}</a>
+    <a class="tag" href="{% url_for controller='package', action='search', extras_taxonomy=tag.name %}">{{ h.odm_nav_get_localized_tag(tag.display_name) }}</a>
   </li>
   {% endfor %}
 </ul>

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '1.0.0'
+version = '1.0.1'
 
 setup(
     name='ckanext-odm_nav',


### PR DESCRIPTION
@chris-aeviator Please note the extras_ prefix for odm_specific fields (defined with scheming). Solr handles them as extras and therefore this PR updates the references to them by appending the prefix mentioned.

You need to change the navigation to something like:

../laws_records?extras_odm_spatial_range=kh (note that value is country code, not country name)
../laws_records?extras_taxonomy=Labor ( here value equals tag name, I believe CKAN sanitizes the string internally before searching ).

Pleas merge, integrate with your code and deploy
