### PR TITLE
Impr layout pp

### DIFF
--- a/ckanext/odm_nav/fanstatic/aeviator_nav_concept.css
+++ b/ckanext/odm_nav/fanstatic/aeviator_nav_concept.css
@@ -284,7 +284,8 @@ li.menu_people>a>img{
 }
 
 .container {
-  margin-left: 140px;
+  margin-left: 0px;
+  margin-right: 0px;
 }
 
 .clearfix:after {
@@ -375,11 +376,16 @@ ul.level1 {
 /*#############################################################################################
  *############################################################################################ */
 /*top nav */
+
+.content_wrapper {
+  padding-left: 140px;
+}
+
 .contentNavigation {
   height: 60px;
   /*top: 30px;*/
   position: relative;
-  padding-left: 140px;
+  /*padding-left: 140px;*/
   /*z-index: 100; */
   /*margin-left: -30px; */
 }
@@ -387,8 +393,6 @@ ul.level1 {
 #cNavNew {
   display: inline-block;
   position: relative;
-  width: 100%;
-  width: 100vw;
   padding-left: 40px;
   z-index: 8888;
   /*-moz-box-shadow: 0px 2px 3px 0px #ddd;

--- a/ckanext/odm_nav/templates/footer.html
+++ b/ckanext/odm_nav/templates/footer.html
@@ -42,3 +42,5 @@
     {% endif %}
   {% endblock %}
 </footer>
+
+</div>

--- a/ckanext/odm_nav/templates/header.html
+++ b/ckanext/odm_nav/templates/header.html
@@ -2,7 +2,7 @@
 
 {% block header_wrapper %}
 <div class="content_wrapper">
-  
+
 {% block header_account %}
 <header class="account-masthead">
 
@@ -77,7 +77,7 @@
  <div class="debug">Controller : {{ c.controller }}<br/>Action : {{ c.action }}</div>
  {% endif %}
  {% endblock %}
-
+ <div class="container">
 
   {# The .header-image class hides the main text and uses image replacement for the title #}
   <hgroup class="{{ g.header_class }}">
@@ -123,6 +123,8 @@
 
    </div>
 
+
+</div>
  </header>
 
 

--- a/ckanext/odm_nav/templates/header.html
+++ b/ckanext/odm_nav/templates/header.html
@@ -1,7 +1,8 @@
 {% resource 'odm_nav/cookie.js' %}
 
-
 {% block header_wrapper %}
+<div class="content_wrapper">
+  
 {% block header_account %}
 <header class="account-masthead">
 
@@ -76,7 +77,7 @@
  <div class="debug">Controller : {{ c.controller }}<br/>Action : {{ c.action }}</div>
  {% endif %}
  {% endblock %}
- <div class="container">
+
 
   {# The .header-image class hides the main text and uses image replacement for the title #}
   <hgroup class="{{ g.header_class }}">
@@ -121,7 +122,7 @@
     {% endblock %}
 
    </div>
-  </div>
+
  </header>
 
 

--- a/ckanext/odm_nav/templates/home/layout1.html
+++ b/ckanext/odm_nav/templates/home/layout1.html
@@ -1,5 +1,5 @@
 <div role="main" class="hero">
-  <div class="intro">
+  <div class="container intro">
     <div class="row row1">
      <div class="span8 col1">
       <h1>{{ _('Welcome to Open Development Datahub') }}</h1>

--- a/ckanext/odm_nav/templates/home/layout1.html
+++ b/ckanext/odm_nav/templates/home/layout1.html
@@ -1,7 +1,7 @@
 <div role="main" class="hero">
-  <div class="container intro">
+  <div class="intro">
     <div class="row row1">
-     <div class="span9 col1">
+     <div class="span8 col1">
       <h1>{{ _('Welcome to Open Development Datahub') }}</h1>
       <p>{{ _('Open Development Mekong (OD Mekong) provides information on development trends in the Mekong Region to increase public awareness, enable individual analysis, improve information sharing, and inform debate - all contributing to sustainable development from a social, economic and environmental perspective.') }}</p>
       <div class="intro-buttons">


### PR DESCRIPTION
@chris-aeviator this is how I imagine the DIV layout for the sidebar. I have added a content_wrapper DIV which wraps all the content and adds padding-left: 140px so the content is shifted to the right of the sidebar per default. With this, not only the problem I had is fixed but it makes more sense cause you can set width:100% in the children components which will allow to layout the content better, since all the elements are going to be constrained within the content_wrapper. 

FYI: This is a PR from a branch I created to impl-1_PP, so please test and integrate in impl-1_PP if you agree

I would employ the same technique in ODM WP frontend.

Also a question/suggestion for you and @kathi-aeviator: What is the plan for the footer on CKAN? I would suggest to change its color to something similar to the overall background color in CKAN, otherwise when the user scrolls down, the color of the footer gets mixed with the sidebar.
