### PR TITLE
Fixes #43

### DIFF
--- a/ckanext/odm_nav/lib/odm_nav_helper.py
+++ b/ckanext/odm_nav/lib/odm_nav_helper.py
@@ -56,10 +56,10 @@ def load_country_specific_menu(country):
     jsonData = r.json()
     return jsonData['items']
 
-  except(requests.exceptions.ConnectionError):
+  except:
     log.error("cannot create menu for endpoint: " + menu_endpoint)
-
-    return []
+    
+  return []
 
 def get_cookie():
   request=toolkit.request


### PR DESCRIPTION
@chris-aeviator this prevents CKAN from breaking if there is a problem with the WP Menues, which is related to the issue that Proteus has raised.

```
this is the stack trace.
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/paste/cascade.py", line 130, in __call__
    return self.apps[-1](environ, start_response)
  File "./ckan/config/middleware.py", line 226, in __call__
    return self.app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/paste/registry.py", line 379, in __call__
    app_iter = self.application(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/repoze/who/middleware.py", line 87, in __call__
    app_iter = app(environ, wrapper.wrap_start_response)
  File "./pylons/middleware.py", line 214, in __call__
    self.app, new_environ, catch_exc_info=True)
  File "./pylons/util.py", line 94, in call_wsgi_application
    app_iter = application(environ, start_response)
  File "./weberror/errormiddleware.py", line 156, in __call__
    return self.application(environ, start_response)
  File "./webob/dec.py", line 147, in __call__
    resp = self.call_func(req, *args, **self.kwargs)
  File "./webob/dec.py", line 208, in call_func
    return self.func(req, *args, **kwargs)
  File "./fanstatic/publisher.py", line 234, in __call__
    return request.get_response(self.app)
  File "./webob/request.py", line 1053, in get_response
    application, catch_exc_info=False)
  File "./webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "./webob/dec.py", line 147, in __call__
    resp = self.call_func(req, *args, **self.kwargs)
  File "./webob/dec.py", line 208, in call_func
    return self.func(req, *args, **kwargs)
  File "./fanstatic/injector.py", line 54, in __call__
    response = request.get_response(self.app)
  File "./webob/request.py", line 1053, in get_response
    application, catch_exc_info=False)
  File "./webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)                                                                                              [78/459]
  File "./beaker/middleware.py", line 73, in __call__
    return self.app(environ, start_response)
  File "./beaker/middleware.py", line 155, in __call__
    return self.wrap_app(environ, session_start_response)
  File "./routes/middleware.py", line 131, in __call__
    response = self.app(environ, start_response)
  File "./pylons/wsgiapp.py", line 125, in __call__
    response = self.dispatch(controller, environ, start_response)
  File "./pylons/wsgiapp.py", line 324, in dispatch
    return controller(environ, start_response)
  File "./ckan/lib/base.py", line 338, in __call__
    res = WSGIController.__call__(self, environ, start_response)
  File "./pylons/controllers/core.py", line 221, in __call__
    response = self._dispatch_call()
  File "./pylons/controllers/core.py", line 172, in _dispatch_call
    response = self._inspect_call(func)
  File "./pylons/controllers/core.py", line 107, in _inspect_call
    result = self._perform_call(func, args)
  File "./pylons/controllers/core.py", line 60, in _perform_call
    return func(**args)
  File "./ckan/controllers/error.py", line 40, in document
    return render('error_document_template.html')
  File "./ckan/lib/base.py", line 217, in render
    loader_class=loader_class)
  File "./pylons/templating.py", line 249, in cached_template
    return render_func()
  File "./ckan/lib/base.py", line 155, in render_template
    return render_jinja2(template_name, globs)
  File "./ckan/lib/base.py", line 104, in render_jinja2
    return template.render(**extra_vars)
  File "./jinja2/environment.py", line 894, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python2.7/dist-packages/ckan/templates/error_document_template.html", line 1, in top-level template code
    {% extends "page.html" %}
  File "/usr/local/lib/python2.7/dist-packages/ckan/templates/page.html", line 1, in top-level template code
    {% extends "base.html" %}
  File "/usr/local/lib/python2.7/dist-packages/ckanext/geoview/templates/base.html", line 1, in top-level template code
    {% ckan_extends %}
  File "/usr/local/lib/python2.7/dist-packages/ckanext/odm_laws/templates/base.html", line 1, in top-level template code
    {% ckan_extends %}
  File "/usr/local/lib/python2.7/dist-packages/ckanext/odm_library/templates/base.html", line 1, in top-level template code
    {% ckan_extends %}
  File "/usr/local/lib/python2.7/dist-packages/ckanext/odm_dataset/templates/base.html", line 1, in top-level template code
    {% ckan_extends %}
  File "/usr/local/lib/python2.7/dist-packages/ckanext/odm_nav/templates/base.html", line 108, in top-level template code
    {%- block page %}{% endblock -%}
  File "/usr/local/lib/python2.7/dist-packages/ckan/templates/page.html", line 14, in block "page"
    {%- block header %}
  File "/usr/local/lib/python2.7/dist-packages/ckan/templates/page.html", line 15, in block "header"
    {% include "header.html" %}
  File "/usr/local/lib/python2.7/dist-packages/ckanext/odm_laws/templates/header.html", line 1, in top-level template code
    {% ckan_extends %}
  File "/usr/local/lib/python2.7/dist-packages/ckanext/odm_library/templates/header.html", line 1, in top-level template code
    {% ckan_extends %}
  File "/usr/local/lib/python2.7/dist-packages/ckanext/odm_nav/templates/header.html", line 3, in top-level template code
    {% block header_wrapper %}
  File "/usr/local/lib/python2.7/dist-packages/ckanext/odm_nav/templates/header.html", line 100, in block "header_wrapper"
    {% snippet 'snippets/top_topics.html'%}
  File "./ckan/lib/jinja_extensions.py", line 255, in _call
    return base.render_snippet(args[0], **kwargs)
  File "./ckan/lib/base.py", line 79, in render_snippet
    renderer='snippet')
  File "./ckan/lib/base.py", line 217, in render
    loader_class=loader_class)
  File "./pylons/templating.py", line 249, in cached_template
    return render_func()
  File "./ckan/lib/base.py", line 155, in render_template
    return render_jinja2(template_name, globs)
  File "./ckan/lib/base.py", line 104, in render_jinja2
    return template.render(**extra_vars)
  File "./jinja2/environment.py", line 894, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python2.7/dist-packages/ckanext/odm_nav/templates/snippets/top_topics.html", line 111, in top-level template code
    {% for item in h.odm_nav_load_country_specific_menu(country_code) %}
  File "/usr/local/lib/python2.7/dist-packages/ckanext/odm_nav/lib/odm_nav_helper.py", line 56, in load_country_specific_menu
    jsonData = r.json()
  File "./requests/models.py", line 604, in json
    return json.loads(self.text or self.content)
  File "/usr/lib/python2.7/dist-packages/simplejson/__init__.py", line 488, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/dist-packages/simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "/usr/lib/python2.7/dist-packages/simplejson/decoder.py", line 389, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
simplejson.scanner.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
