### PR TITLE
Fix 19 - Forward to country landingpage if top topics not set for country

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,40 @@ In order to install this CKAN Extension:
  * Setup plugin
  <code>python setup.py develop</code>
 
+# Configuration
+
+## Wordpress domain
+
+Please set wordpress main domain
+```
+ckan.odm_nav_concept.wp_domain = opendevelopmentmekong.net
+```
+
+## Wordpress Menu Endpoints
+
+In order to have the WP menu loaded into CKAN you need to provide the json api menu endpoints in the ckan config file.
+
+```
+ckan.odm_nav_concept.mekong_menu_endpoint = https://pp.opendevelopmentmekong.net/wp-json/menus/847
+ckan.odm_nav_concept.cambodia_menu_endpoint = https://pp-cambodia.opendevelopmentmekong.net/wp-json/menus/43025
+ckan.odm_nav_concept.thailand_menu_endpoint = https://pp-thailand.opendevelopmentmekong.net/wp-json/menus/10
+ckan.odm_nav_concept.laos_menu_endpoint = https://pp-laos.opendevelopmentmekong.net/wp-json/menus/9
+ckan.odm_nav_concept.vietnam_menu_endpoint = https://pp-vietnam.opendevelopmentmekong.net/wp-json/menus/572
+ckan.odm_nav_concept.myanmar_menu_endpoint = https://pp-myanmar.opendevelopmentmekong.net/wp-json/menus/9
+```
+
+## Disable Top Topics Menu Links
+
+If a certain WP country-sub-site does not have top topic content enabled, you should disable the links to the topic pages. By setting
+
+```
+ckan.odm_nav_concept.disable_top_topic_links_for_countries = laos myanmar vietnam thailand
+```
+
+The top topic links on ckan site for laos, myanmar, vietnam & thailand are set to the corresponding landing pages (COUNTRY at a glance).
+
+When ```ckan.odm_nav_concept.disable_top_topic_links_for_countries```is not set, all top topic links are enabled by default!
+
 # Testing
 
   Run ```nosetest```

--- a/ckanext/odm_nav/lib/odm_nav_helper.py
+++ b/ckanext/odm_nav/lib/odm_nav_helper.py
@@ -36,6 +36,10 @@ country_menus = dict({
 
 disabled_top_topic_links=toolkit.aslist(config.get('ckan.odm_nav_concept.disable_top_topic_links_for_countries', []))
 
+
+
+
+
 def get_wp_domain():
   log.info('get_wp_domain')
   return config.get("ckan.odm_nav_concept.wp_domain")
@@ -174,6 +178,11 @@ def tag_for_topic(topic):
   tag_name = ''.join(ch for ch in topic if (ch.isalnum() or ch == '_' or ch == '-' or ch == ' ' ))
   return tag_name if len(tag_name)<=100 else tag_name[0:99]
 
+def check_top_topics_disabled(country_code):
+  for item in disabled_top_topic_links:
+    if item == country_code:
+      return True
+      
 def recent_datasets():
   '''Return a sorted list of the datasets updated recently.'''
 

--- a/ckanext/odm_nav/lib/odm_nav_helper.py
+++ b/ckanext/odm_nav/lib/odm_nav_helper.py
@@ -33,6 +33,9 @@ country_menus = dict({
   "myanmar": config.get("ckan.odm_nav_concept.myanmar_menu_endpoint")
 })
 
+
+disabled_top_topic_links=toolkit.aslist(config.get('ckan.odm_nav_concept.disable_top_topic_links_for_countries', []))
+
 def get_wp_domain():
   log.info('get_wp_domain')
   return config.get("ckan.odm_nav_concept.wp_domain")
@@ -58,7 +61,7 @@ def load_country_specific_menu(country):
 
   except:
     log.error("cannot create menu for endpoint: " + menu_endpoint)
-    
+
   return []
 
 def get_cookie():

--- a/ckanext/odm_nav/plugin.py
+++ b/ckanext/odm_nav/plugin.py
@@ -105,7 +105,8 @@ class OdmNavPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
       'odm_nav_json_load_top_topics':odm_nav_helper.json_load_top_topics,
       'odm_nav_sanitize_html':odm_nav_helper.sanitize_html,
       'odm_nav_get_cookie': odm_nav_helper.get_cookie,
-      'odm_nav_load_country_specific_menu': odm_nav_helper.load_country_specific_menu
+      'odm_nav_load_country_specific_menu': odm_nav_helper.load_country_specific_menu,
+      'odm_nav_check_top_topics_disabled' : odm_nav_helper.check_top_topics_disabled
 	}
 
   # IPackageController

--- a/ckanext/odm_nav/templates/snippets/top_topics.html
+++ b/ckanext/odm_nav/templates/snippets/top_topics.html
@@ -42,9 +42,9 @@
     				<li class="top-topic">{{item.titles.en}}</li>
     				{%for child in item.children %}
     				    <li class="first">
-									{% if country_code=='d'%}
+									{% if country_code==''%}
 										<a href="https://{{wp_domain}}/topics/{{h.odm_nav_sanitize_html(child.titles.en)}}" target="_self">{{child.titles.en}}<span class="cNavState"></span></a>
-									{% elif h.odm_nav_check_top_topics_disabled('thailand') == True %}
+									{% elif h.odm_nav_check_top_topics_disabled(country_code) == True %}
 										<a href="https://{{country_code}}.{{wp_domain}}" target="_self">{{child.titles.en}}<span class="cNavState"></span></a>
 									{% else %}
 										<a href="https://{{country_code}}.{{wp_domain}}/topics/{{h.odm_nav_sanitize_html(child.titles.en)}}" target="_self">{{child.titles.en}}<span class="cNavState"></span></a>

--- a/ckanext/odm_nav/templates/snippets/top_topics.html
+++ b/ckanext/odm_nav/templates/snippets/top_topics.html
@@ -42,8 +42,10 @@
     				<li class="top-topic">{{item.titles.en}}</li>
     				{%for child in item.children %}
     				    <li class="first">
-									{% if country_code==''%}
+									{% if country_code=='d'%}
 										<a href="https://{{wp_domain}}/topics/{{h.odm_nav_sanitize_html(child.titles.en)}}" target="_self">{{child.titles.en}}<span class="cNavState"></span></a>
+									{% elif h.odm_nav_check_top_topics_disabled('thailand') == True %}
+										<a href="https://{{country_code}}.{{wp_domain}}" target="_self">{{child.titles.en}}<span class="cNavState"></span></a>
 									{% else %}
 										<a href="https://{{country_code}}.{{wp_domain}}/topics/{{h.odm_nav_sanitize_html(child.titles.en)}}" target="_self">{{child.titles.en}}<span class="cNavState"></span></a>
 									{% endif %}


### PR DESCRIPTION
Please check proposed implementation and if https://github.com/OpenDevelopmentMekong/ckanext-odm_nav/compare/fix-19?expand=1#diff-46755a2818ff8b9c240c0ecf717e0b57R184 is a valid python approach ( not returning something if country_code is not in list )

For the proposed solution the setting 
`ckan.odm_nav_concept.disable_top_topic_links_for_countries = laos myanmar vietnam thailand`

has been added to the ckan configuration file
